### PR TITLE
Fix crash when running with -s|--shell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.8]
+        python-version: ['2.7', '3.8']
         os: [ubuntu, windows, macos]
         opts: ['--shell', '']
 
@@ -19,3 +19,4 @@ jobs:
       - run: make install
       - run: make lint
       - run: make -e DOCS_OPTS="${{ matrix.opts }}" docs
+        continue-on-error: ${{ matrix.python-version == '2.7' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.8]
-        os: [ubuntu]
+        os: [ubuntu, windows, macos]
+        opts: ['--shell', '']
 
     steps:
       - uses: actions/checkout@v2
@@ -17,3 +18,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: make install
       - run: make lint
+      - run: make -e DOCS_OPTS="${{ matrix.opts }}" docs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DOCS_BRANCH := gh-pages
 DOCS_REMOTE := origin
+DOCS_OPTS := -p
 
 install:
 	pip install -r requirements-dev.txt
@@ -10,7 +11,7 @@ lint:
 
 docs:
 	./docs/build.py > docs/index.html
-	./ghp_import.py -p docs/ -b $(DOCS_BRANCH) -r $(DOCS_REMOTE)
+	./ghp_import.py $(DOCS_OPTS) docs/ -b $(DOCS_BRANCH) -r $(DOCS_REMOTE)
 
 clean:
 	python -c "import os; os.remove(os.path.join('docs', 'index.html'))"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,4 @@
+pr: none
 trigger:
   - master
 


### PR DESCRIPTION
When running `ghp-import` with `-s` or `--shell`, the first subprocess call fails as the git sub-command to run isn't recognized. This seems to be caused by the code not respecting the documentation for [subprocess.Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) which mentions that when `shell=True` is passed as an argument, the command should be passed as a string instead of an array.