### PR TITLE
Only delete files in prefix if specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ take backups before playing with this. This script assumes that `gh-pages` is
 100% derivative. You should never edit files in your `gh-pages` branch by hand
 if you're using this script because you will lose your work.
 
+When used with a prefix, only files blow the set prefix will be destroyed, limiting the
+above warning to just that directory and everything below it.
+
 Usage
 -----
 
@@ -61,7 +64,8 @@ Options:
   -p, --push            Push the branch to origin/{branch} after committing.
   -x PREFIX, --prefix=PREFIX
                         The prefix to add to each file that gets pushed to the
-                        remote. [none]
+                        remote. Only files below this prefix will be cleared
+                        out. [none]
   -f, --force           Force the push to the repository.
   -o, --no-history      Force new commit without parent history.
   -r REMOTE, --remote=REMOTE

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ take backups before playing with this. This script assumes that `gh-pages` is
 100% derivative. You should never edit files in your `gh-pages` branch by hand
 if you're using this script because you will lose your work.
 
-When used with a prefix, only files blow the set prefix will be destroyed, limiting the
+When used with a prefix, only files below the set prefix will be destroyed, limiting the
 above warning to just that directory and everything below it.
 
 Usage


### PR DESCRIPTION
We'd like to have multiple parallel versions of our docs in the same branch.
Deleting all files on the branch each time is thus way too destructive.

This changes the behaviour so that if a prefix is specified, only that prefix is deleted and the rest of the branch is left alone.