### PR TITLE
place `.nojekyll` under prefix directory for ghp discovery

### DIFF
--- a/ghp_import.py
+++ b/ghp_import.py
@@ -154,8 +154,11 @@ def add_file(pipe, srcpath, tgtpath):
         write(pipe, enc('\n'))
 
 
-def add_nojekyll(pipe):
-    write(pipe, enc('M 100644 inline .nojekyll\n'))
+def add_nojekyll(pipe, prefix=None):
+    if prefix:
+        write(pipe, enc('M 100644 inline %s\n' % os.path.join(prefix, '.nojekyll')))
+    else:
+        write(pipe, enc('M 100644 inline .nojekyll\n'))
     write(pipe, enc('data 0\n'))
     write(pipe, enc('\n'))
 
@@ -183,7 +186,7 @@ def run_import(git, srcdir, **opts):
                 gpath = os.path.join(opts['prefix'], gpath)
             add_file(pipe, fpath, gpath)
     if opts['nojekyll']:
-        add_nojekyll(pipe)
+        add_nojekyll(pipe, opts['prefix'])
     if opts['cname'] is not None:
         add_cname(pipe, opts['cname'])
     write(pipe, enc('\n'))

--- a/ghp_import.py
+++ b/ghp_import.py
@@ -156,9 +156,10 @@ def add_file(pipe, srcpath, tgtpath):
 
 def add_nojekyll(pipe, prefix=None):
     if prefix:
-        write(pipe, enc('M 100644 inline %s\n' % os.path.join(prefix, '.nojekyll')))
+        fpath = os.path.join(prefix, '.nojekyll')
     else:
-        write(pipe, enc('M 100644 inline .nojekyll\n'))
+        fpath = '.nojekyll'
+    write(pipe, enc('M 100644 inline %s\n' % fpath))
     write(pipe, enc('data 0\n'))
     write(pipe, enc('\n'))
 


### PR DESCRIPTION
Test steps: [Script](https://gist.github.com/achekerylla/51efd9c046ac4744b77e64af013f771b#file-ghp-import-issues-106-sh)

1. set up ghp-import workspace
2. set up project workspace
3. run ghp-import
4. check gh-pages branch for nojekyll files

```
# ghp-import--issues-106.sh: adhoc tests for pull request

  echo "** run ghp-import"
  ghp-import \
    --no-jekyll \
    --push \
    --prefix=docs \
    --force \
    --no-history \
    ${MY_BOOK_DIR}/_build/html \
    || echo "WARNING: ghp-import failed"
```



Results on testing branch: [Log](https://gist.github.com/achekerylla/51efd9c046ac4744b77e64af013f771b#file-ghp-import-issues-106-sh-log-1-L57-L59)
```
$ ghp-import--issues-106.sh -t

** check gh-pages branch for nojekyll files 
+ find . -name .nojekyll
./docs/.nojekyll
```

Results on master branch: [Log](https://gist.github.com/achekerylla/51efd9c046ac4744b77e64af013f771b#file-ghp-import-issues-106-sh-log-2-L57-L59)

```
$ ghp-import--issues-106.sh -r

** check gh-pages branch for nojekyll files 
+ find . -name .nojekyll
./.nojekyll
```